### PR TITLE
Show image attachments in a nice JS lightbox.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.409</version>
+        <version>1.424</version>
     </parent>
 
     <artifactId>junit-attachments</artifactId>
@@ -36,13 +36,20 @@
         </developer>
     </developers>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jquery</artifactId>
+            <version>1.7.2-1</version>
+        </dependency>
+    </dependencies>
+
     <repositories>
       <repository>
         <id>repo.jenkins-ci.org</id>
         <url>http://repo.jenkins-ci.org/public/</url>
       </repository>
     </repositories>
-    
 
     <pluginRepositories>
         <pluginRepository>

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
@@ -56,5 +56,8 @@ public class AttachmentTestAction extends TestAction {
 		return testObject;
 	}
 
+	public static boolean isImageFile(String filename) {
+		return filename.matches("(?i).+\\.(gif|jpe?g|png)$");
+	}
 
 }

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
@@ -2,7 +2,7 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 	<tr><td>
-	<H3>Attachments</H3>
+	<h3>${%Attachments}</h3>
 	<table class="pane" id="attachments">
 		<tr>
 			<td class="pane-header">${%Files}</td>
@@ -10,10 +10,20 @@
 			<j:forEach var="attachment" items="${it.attachments}">
 				<tr>
 					<td class="pane">
-						<a href="attachments/${attachment}">${attachment}</a>
+						<a class="${it.isImageFile(attachment) ? 'gallery' : ''}"
+						   title="${attachment}"
+						   href="attachments/${attachment}">${attachment}</a>
 					</td>
 				</tr>
 			</j:forEach>
 	</table>
 	</td></tr>
+
+    <st:adjunct includes="hudson.plugins.jquery.colorbox" />
+    <script type="text/javascript">
+        Q(document).ready(function() {
+            Q("a.gallery").colorbox({rel: "gallery", maxWidth: "95%", maxHeight: "95%", speed: 150});
+        });
+    </script>
+
 </j:jelly>


### PR DESCRIPTION
When clicking on an image attachment, it's now shown on the same page, in a nice lightbox.

![Attachment in a lightbox](http://i.imgur.com/TFx3h.png)
