### PR TITLE
Fix some issue : register action from newer jenkins version, hack so that maven test can work...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.593</version>
     </parent>
 
     <artifactId>junit-attachments</artifactId>
@@ -48,6 +48,13 @@
             <artifactId>jquery</artifactId>
             <version>1.7.2-1</version>
         </dependency>
+        
+        <dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>junit</artifactId>
+			<version>1.3</version>
+		</dependency>
+        
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
 			<version>1.3</version>
 		</dependency>
         
+        <dependency>
+  			<groupId>commons-beanutils</groupId>
+  			<artifactId>commons-beanutils</artifactId>
+  			<version>1.8.3</version>
+  			<scope>test</scope>
+		</dependency>
+        
     </dependencies>
 
     <repositories>

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
@@ -10,9 +10,14 @@
 			<j:forEach var="attachment" items="${it.attachments}">
 				<tr>
 					<td class="pane">
-						<a class="${it.isImageFile(attachment) ? 'gallery' : ''}"
-						   title="${attachment}"
-						   href="attachments/${attachment}">${attachment}</a>
+						<j:if test="${it.isImageFile(attachment)}">
+							<a class="gallery" title="${attachment}" href="attachments/${attachment}" style="width:300px;">
+								<img src="attachments/${attachment}"  /> 
+							</a>
+						</j:if>
+						<j:if test="${!it.isImageFile(attachment)}">
+						    <a title="${attachment}" href="attachments/${attachment}">${attachment}</a>
+						</j:if>
 					</td>
 				</tr>
 			</j:forEach>


### PR DESCRIPTION
Hello,

With a 1.593 version how jenkins, the junit attachment plugin was not working.
I added the junit plugin dependencies in the pom so that it could be registered
setup a snapshot view for image 
and add a hack that fix the url so that maven test (maven work by module) can display attachment.

It's not perfect, it works in my case... hope it can help...