### PR TITLE
[JENKINS-26275] Fixed

### DIFF
--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
@@ -10,9 +10,14 @@
 			<j:forEach var="attachment" items="${it.attachments}">
 				<tr>
 					<td class="pane">
-						<a class="${it.isImageFile(attachment) ? 'gallery' : ''}"
-						   title="${attachment}"
-						   href="attachments/${attachment}">${attachment}</a>
+						<j:if test="${it.isImageFile(attachment)}">
+							<a class="gallery" title="${attachment}" href="attachments/${attachment}" style="width:300px;">
+								<img src="attachments/${attachment}"  /> 
+							</a>
+						</j:if>
+						<j:if test="${!it.isImageFile(attachment)}">
+						    <a title="${attachment}" href="attachments/${attachment}">${attachment}</a>
+						</j:if>
 					</td>
 				</tr>
 			</j:forEach>


### PR DESCRIPTION
Show snapshot instead of link when attachment is image

Small feature but interresting one if you have image that can be understood even if not in full size.
With this, no need to click one more time, you have all you need at first glance.
