### PR TITLE
[JENKINS-19430] Fix publishing of attachments for maven module builds

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -34,7 +34,7 @@ public class AttachmentPublisher extends TestDataPublisher {
     }
 
     public static FilePath getAttachmentPath(AbstractBuild<?, ?> build) {
-        return new FilePath(new File(build.getRootDir().getAbsolutePath()))
+        return new FilePath(new File(build.getRootBuild().getRootDir().getAbsolutePath()))
                 .child("junit-attachments");
     }
 


### PR DESCRIPTION
This will resolve #8 , using the diff from Marco Neumann's comment at https://issues.jenkins-ci.org/browse/JENKINS-19430.
