### PR TITLE
[FIXED JENKINS-28784] Add Pipeline support for junit-attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings
 target
 work
+.idea
+junit-attachments.iml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>2.5</version>
     </parent>
 
     <artifactId>junit-attachments</artifactId>
@@ -27,6 +27,9 @@
             compare: http://docs.codehaus.org/display/MAVENUSER/POM+Element+for+Source+File+Encoding
         -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jenkins.version>1.609.3</jenkins.version>
+        <jenkins-test-harness.version>2.7</jenkins-test-harness.version>
+        <java.level>6</java.level>
     </properties>
 
     <developers>
@@ -47,6 +50,37 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jquery</artifactId>
             <version>1.7.2-1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.14-SNAPSHOT</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.5</version>
+        <version>2.11</version>
     </parent>
 
     <artifactId>junit-attachments</artifactId>
@@ -61,25 +61,25 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.0</version>
+            <version>1.14.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.0</version>
+            <version>1.14.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.0</version>
+            <version>1.14.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.0</version>
+            <version>1.14.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
         -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jenkins.version>1.609.3</jenkins.version>
-        <jenkins-test-harness.version>2.7</jenkins-test-harness.version>
         <java.level>6</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.14-SNAPSHOT</version>
+            <version>1.14</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -150,10 +150,10 @@ public class AttachmentPublisher extends TestDataPublisher {
                 //
                 // This means that all attachments will appear on the test class page as before,
                 // but they won't also be repeated on each individual test method's page
-                for (String testClass : attachments.keySet()) {
+                for (Map.Entry<String,List<String>> entry : attachments.entrySet()) {
                     HashMap<String, List<String>> testMap = new HashMap<String, List<String>>();
-                    testMap.put("", attachments.get(testClass));
-                    attachmentsMap.put(testClass, testMap);
+                    testMap.put("", entry.getValue());
+                    attachmentsMap.put(entry.getKey(), testMap);
                 }
                 attachments = null;
             }

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -8,8 +8,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.BuildListener;
-import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
 import hudson.tasks.junit.TestAction;
 import hudson.tasks.junit.TestDataPublisher;
@@ -62,20 +60,6 @@ public class AttachmentPublisher extends TestDataPublisher {
         return new Data(attachments);
     }
 
-    @Override
-    public Data getTestData(AbstractBuild<?, ?> build, Launcher launcher,
-                            BuildListener listener, TestResult testResult) throws IOException,
-            InterruptedException {
-        final GetTestDataMethodObject methodObject = new GetTestDataMethodObject(build, launcher, listener, testResult);
-        Map<String, Map<String, List<String>>> attachments = methodObject.getAttachments();
-
-        if (attachments.isEmpty()) {
-            return null;
-        }
-
-        return new Data(attachments);
-    }
-
     public static class Data extends TestResultAction.Data {
 
         @Deprecated
@@ -83,7 +67,7 @@ public class AttachmentPublisher extends TestDataPublisher {
         private Map<String, Map<String, List<String>>> attachmentsMap;
 
         /**
-         * @param attachmentsMap { fully-qualified test class name -&gt; { test method name -&gt; [ attachment file name ] } }
+         * @param attachmentsMap { fully-qualified test class name → { test method name → [ attachment file name ] } }
          */
         public Data(Map<String, Map<String, List<String>>> attachmentsMap) {
             this.attachmentsMap = attachmentsMap;

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
@@ -2,10 +2,9 @@ package hudson.plugins.junitattachments;
 
 import hudson.FilePath;
 import hudson.model.DirectoryBrowserSupport;
-import hudson.model.Hudson;
 import hudson.tasks.junit.TestAction;
-import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.TestObject;
+import jenkins.model.Jenkins;
 
 import java.util.List;
 
@@ -39,7 +38,7 @@ public class AttachmentTestAction extends TestAction {
 
 	@Override
 	public String annotate(String text) {
-		String url = Hudson.getInstance().getRootUrl()
+		String url = Jenkins.getActiveInstance().getRootUrl()
 				+ testObject.getOwner().getUrl() + "testReport"
 				+ testObject.getUrl() + "/attachments/";
 		for (String attachment : attachments) {

--- a/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
+++ b/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
@@ -63,6 +63,7 @@ public class GetTestDataMethodObject {
      * @param testResult
      *            see {@link GetTestDataMethodObject#testResult}
      */
+    @Deprecated
     public GetTestDataMethodObject(AbstractBuild<?, ?> build, @SuppressWarnings("unused") Launcher launcher,
             TaskListener listener, TestResult testResult) {
         this.build = build;

--- a/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
+++ b/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
@@ -27,8 +27,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * This class is a helper for hudson.tasks.junit.TestDataPublisher.getTestData(AbstractBuild&lt;?, ?&gt;, Launcher,
- * BuildListener, TestResult).
+ * This class is a helper for {@code hudson.tasks.junit.TestDataPublisher.getTestData(AbstractBuild<?, ?>, Launcher,
+ * BuildListener, TestResult)}.
  *
  * @author mfriedenhagen
  * @author Kohsuke Kawaguchi

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/sidepanel.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/sidepanel.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/sidepanel.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/sidepanel.jelly
@@ -2,6 +2,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	
-	<st:include from="${it.testObject.owner}" it="${it.testObject.owner}" page="sidepanel.jelly" />
+	<st:include from="${it.testObject.run}" it="${it.testObject.run}" page="sidepanel.jelly" />
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/sidepanel.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/sidepanel.jelly
@@ -2,6 +2,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	
-	<st:include from="${it.testObject.run}" it="${it.testObject.run}" page="sidepanel.jelly" />
+	<st:include it="${it.testObject.run}" page="sidepanel.jelly" />
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
@@ -32,7 +32,7 @@ import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -46,8 +46,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class AttachmentPublisherPipelineTest {
-    @ClassRule
-    public static JenkinsRule jenkinsRule = new JenkinsRule();
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
 
     @Test
     public void testWellKnownFilenamesAreAttached() throws Exception {
@@ -74,7 +74,11 @@ public class AttachmentPublisherPipelineTest {
         FilePath wsZip = workspace.child("workspace.zip");
         wsZip.copyFrom(getClass().getResource(workspaceZip));
         wsZip.unzip(workspace);
-        project.setDefinition(new CpsFlowDefinition(fileContentsFromResources(pipelineFile)));
+        for (FilePath f : workspace.list()) {
+            f.touch(System.currentTimeMillis());
+        }
+
+        project.setDefinition(new CpsFlowDefinition(fileContentsFromResources(pipelineFile), true));
 
         WorkflowRun r = project.scheduleBuild2(0).waitForStart();
 

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+package hudson.plugins.junitattachments;
+
+import hudson.FilePath;
+import hudson.model.Result;
+import hudson.tasks.junit.ClassResult;
+import hudson.tasks.junit.TestResultAction;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import static hudson.plugins.junitattachments.AttachmentPublisherTest.getClassResult;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class AttachmentPublisherPipelineTest {
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void testWellKnownFilenamesAreAttached() throws Exception {
+        TestResultAction action = getTestResultActionForPipeline("workspace.zip", "pipelineTest.groovy", Result.SUCCESS);
+
+        ClassResult cr = getClassResult(action, "test.foo.bar", "DefaultIntegrationTest");
+
+        AttachmentTestAction ata = cr.getTestAction(AttachmentTestAction.class);
+        assertNotNull(ata);
+
+        final List<String> attachments = ata.getAttachments();
+        assertNotNull(attachments);
+        assertEquals(2, attachments.size());
+
+        Collections.sort(attachments);
+        assertEquals("file", attachments.get(0));
+        assertEquals("test.foo.bar.DefaultIntegrationTest-output.txt", attachments.get(1));
+    }
+
+    // Creates a job from the given workspace zip file, builds it and retrieves the TestResultAction
+    private TestResultAction getTestResultActionForPipeline(String workspaceZip, String pipelineFile, Result expectedStatus) throws Exception {
+        WorkflowJob project = jenkinsRule.jenkins.createProject(WorkflowJob.class, "test-job");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(project);
+        FilePath wsZip = workspace.child("workspace.zip");
+        wsZip.copyFrom(getClass().getResource(workspaceZip));
+        wsZip.unzip(workspace);
+        project.setDefinition(new CpsFlowDefinition(fileContentsFromResources(pipelineFile)));
+
+        WorkflowRun r = project.scheduleBuild2(0).waitForStart();
+
+        jenkinsRule.assertBuildStatus(expectedStatus, jenkinsRule.waitForCompletion(r));
+
+        TestResultAction action = r.getAction(TestResultAction.class);
+        assertNotNull(action);
+
+        return action;
+    }
+
+    private String fileContentsFromResources(String fileName) throws IOException {
+        String fileContents = null;
+
+        URL url = getClass().getResource(fileName);
+        if (url != null) {
+            fileContents = IOUtils.toString(url);
+        }
+
+        return fileContents;
+
+    }
+
+}

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
@@ -80,9 +80,7 @@ public class AttachmentPublisherPipelineTest {
 
         project.setDefinition(new CpsFlowDefinition(fileContentsFromResources(pipelineFile), true));
 
-        WorkflowRun r = project.scheduleBuild2(0).waitForStart();
-
-        jenkinsRule.assertBuildStatus(expectedStatus, jenkinsRule.waitForCompletion(r));
+        WorkflowRun r = jenkinsRule.assertBuildStatus(expectedStatus, project.scheduleBuild2(0).get());
 
         TestResultAction action = r.getAction(TestResultAction.class);
         assertNotNull(action);

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherTest.java
@@ -176,7 +176,7 @@ public class AttachmentPublisherTest extends HudsonTestCase {
     }
 
     // Asserts that, for the given TestResult, the given attachments exist
-    private static void assertAttachmentsExist(TestResult result, String[] expectedFiles) {
+    protected static void assertAttachmentsExist(TestResult result, String[] expectedFiles) {
         AttachmentTestAction ata = result.getTestAction(AttachmentTestAction.class);
         if (expectedFiles == null) {
             assertNull(ata);
@@ -195,11 +195,11 @@ public class AttachmentPublisherTest extends HudsonTestCase {
         }
     }
 
-    private static ClassResult getClassResult(TestResultAction action, String className) {
+    protected static ClassResult getClassResult(TestResultAction action, String className) {
         return getClassResult(action, TEST_PACKAGE, className);
     }
 
-    private static ClassResult getClassResult(TestResultAction action, String packageName, String className) {
+    protected static ClassResult getClassResult(TestResultAction action, String packageName, String className) {
         return action.getResult().byPackage(packageName).getClassResult(className);
     }
 

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherTest.java
@@ -176,7 +176,7 @@ public class AttachmentPublisherTest extends HudsonTestCase {
     }
 
     // Asserts that, for the given TestResult, the given attachments exist
-    protected static void assertAttachmentsExist(TestResult result, String[] expectedFiles) {
+    static void assertAttachmentsExist(TestResult result, String[] expectedFiles) {
         AttachmentTestAction ata = result.getTestAction(AttachmentTestAction.class);
         if (expectedFiles == null) {
             assertNull(ata);
@@ -195,11 +195,11 @@ public class AttachmentPublisherTest extends HudsonTestCase {
         }
     }
 
-    protected static ClassResult getClassResult(TestResultAction action, String className) {
+    static ClassResult getClassResult(TestResultAction action, String className) {
         return getClassResult(action, TEST_PACKAGE, className);
     }
 
-    protected static ClassResult getClassResult(TestResultAction action, String packageName, String className) {
+    static ClassResult getClassResult(TestResultAction action, String packageName, String className) {
         return action.getResult().byPackage(packageName).getClassResult(className);
     }
 

--- a/src/test/resources/hudson/plugins/junitattachments/pipelineTest.groovy
+++ b/src/test/resources/hudson/plugins/junitattachments/pipelineTest.groovy
@@ -23,7 +23,6 @@
  *
  */
 node {
-    sh 'find . -type f -exec touch {} \\;'
     step([$class: 'JUnitResultArchiver', testResults: "*.xml", testDataPublishers: [[$class: 'AttachmentPublisher']]])
 }
 

--- a/src/test/resources/hudson/plugins/junitattachments/pipelineTest.groovy
+++ b/src/test/resources/hudson/plugins/junitattachments/pipelineTest.groovy
@@ -1,0 +1,29 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+node {
+    sh 'find . -type f -exec touch {} \\;'
+    step([$class: 'JUnitResultArchiver', testResults: "*.xml", testDataPublishers: [[$class: 'AttachmentPublisher']]])
+}
+


### PR DESCRIPTION
Also made sure Javadoc doesn't fail when building with Java 8.

Needs https://github.com/jenkinsci/junit-plugin/pull/48 to be merged,
and then released with our POM updated to use that junit version to work.

Also updated parent POM, etc.

cc @reviewbybees esp @jglick 