### PR TITLE
[FIXED JENKINS-36504] Use TestObject.getRun(), not TestObject.getOwner()

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
@@ -39,7 +39,7 @@ public class AttachmentTestAction extends TestAction {
 	@Override
 	public String annotate(String text) {
 		String url = Jenkins.getActiveInstance().getRootUrl()
-				+ testObject.getOwner().getUrl() + "testReport"
+				+ testObject.getRun().getUrl() + "testReport"
 				+ testObject.getUrl() + "/attachments/";
 		for (String attachment : attachments) {
 			text = text.replace(attachment, "<a href=\"" + url + attachment


### PR DESCRIPTION
[JENKINS-36504](https://issues.jenkins-ci.org/browse/JENKINS-36504)

Since TestObject.getOwner() returns an AbstractBuild, it's null for
WorkflowRuns. So that needed to be changed to TestObject.getRun() instead.

cc @reviewbybees