### PR TITLE
[JENKINS-37026] Fix to encode URL to attachments

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
@@ -6,6 +6,8 @@ import hudson.tasks.junit.TestAction;
 import hudson.tasks.test.TestObject;
 import jenkins.model.Jenkins;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.List;
 
 public class AttachmentTestAction extends TestAction {
@@ -58,6 +60,10 @@ public class AttachmentTestAction extends TestAction {
 
 	public static boolean isImageFile(String filename) {
 		return filename.matches("(?i).+\\.(gif|jpe?g|png)$");
+	}
+
+	public static String getUrl(String filename) throws UnsupportedEncodingException {
+		return "attachments/" + URLEncoder.encode(filename, "UTF-8");
 	}
 
 }

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
@@ -13,7 +13,7 @@
 					<td class="pane">
 						<a class="${it.isImageFile(attachment) ? 'gallery' : ''}"
 						   title="${attachment}"
-						   href="attachments/${attachment}">${attachment}</a>
+						   href="${it.getUrl(attachment)}">${attachment}</a>
 					</td>
 				</tr>
 			</j:forEach>


### PR DESCRIPTION
This resolves [JENKINS-37026](https://issues.jenkins-ci.org/browse/JENKINS-37026).
