### PR TITLE
[JENKINS-36305] Fix HTTP404 when browsing test actions from test result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.14</version>
+            <version>1.19-SNAPSHOT</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
@@ -39,7 +39,6 @@ public class AttachmentTestAction extends TestAction {
 	@Override
 	public String annotate(String text) {
 		String url = Jenkins.getActiveInstance().getRootUrl()
-				+ testObject.getRun().getUrl() + "testReport"
 				+ testObject.getUrl() + "/attachments/";
 		for (String attachment : attachments) {
 			text = text.replace(attachment, "<a href=\"" + url + attachment


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/junit-plugin/pull/50
