### PR TITLE
Do not even try to attach a directory

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
+++ b/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
@@ -190,7 +190,9 @@ public class GetTestDataMethodObject {
             String fileName = line;
             if (fileName != null) {
                 FilePath src = workspace.child(fileName); // even though we use child(), this should be absolute
-                if (src.exists()) {
+                if (src.isDirectory()) {
+                    listener.getLogger().println("Attachment " + fileName + " was referenced from the test '" + className + "' but it is a directory, not a file. Skipping.");
+                } else if (src.exists()) {
                     captureAttachment(className, testName, src);
                 } else {
                     listener.getLogger().println("Attachment "+fileName+" was referenced from the test '"+className+"' but it doesn't exist. Skipping.");


### PR DESCRIPTION
Observed [in ATH](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/40/consoleFull) after https://github.com/jenkinsci/acceptance-test-harness/pull/382:

```
java.io.IOException: Is a directory
	at sun.nio.ch.FileDispatcherImpl.read0(Native Method)
	at …
	at java.io.InputStream.read(InputStream.java:101)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1792)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1769)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:1744)
	at hudson.FilePath$41.invoke(FilePath.java:2028)
	at hudson.FilePath$41.invoke(FilePath.java:2024)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:2750)
	at hudson.remoting.UserRequest.perform(UserRequest.java:208)
	at …
	at ......remote call to …
	at …
Caused: java.io.IOException: remote file operation failed: …/target/diagnostics/kerberosTicket(plugins.KerberosSsoTest)/target at hudson.remoting.Channel@…
	at hudson.FilePath.act(FilePath.java:994)
	at hudson.FilePath.act(FilePath.java:976)
	at hudson.FilePath.copyTo(FilePath.java:2024)
	at hudson.FilePath.copyTo(FilePath.java:2000)
Caused: java.io.IOException: Failed to copy …/target/diagnostics/kerberosTicket(plugins.KerberosSsoTest)/target to …/junit-attachments/plugins.KerberosSsoTest/target
	at hudson.FilePath.copyTo(FilePath.java:2003)
	at hudson.plugins.junitattachments.GetTestDataMethodObject.captureAttachment(GetTestDataMethodObject.java:245)
	at hudson.plugins.junitattachments.GetTestDataMethodObject.findAttachmentsInOutput(GetTestDataMethodObject.java:194)
	at hudson.plugins.junitattachments.GetTestDataMethodObject.getReports(GetTestDataMethodObject.java:161)
	at hudson.plugins.junitattachments.GetTestDataMethodObject.getAttachments(GetTestDataMethodObject.java:104)
	at hudson.plugins.junitattachments.AttachmentPublisher.contributeTestData(AttachmentPublisher.java:54)
	at hudson.plugins.junitattachments.AttachmentPublisher.contributeTestData(AttachmentPublisher.java:30)
	at hudson.tasks.junit.JUnitResultArchiver.parseAndAttach(JUnitResultArchiver.java:199)
	at hudson.tasks.junit.JUnitResultArchiver.perform(JUnitResultArchiver.java:153)
	at org.jenkinsci.plugins.junitrealtimetestreporter.RealtimeJUnitStep$Callback.finished(RealtimeJUnitStep.java:166)
	at …
Finished: FAILURE
```

This plugin should be more robust.

@reviewbybees