### PR TITLE
Add `index.jelly` with plugin description

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin can archive certain files (attachments) together with your JUnit results.
+    Attached files are shown in the JUnit results.
+</div>


### PR DESCRIPTION
Maybe `maven-hpi-plugin` ought to fail the build if this is missing?
