### PR TITLE
Use modern `jenkins-table` to list attachments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.332.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
@@ -44,8 +44,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
-                <version>1289.v5c4b_1c43511b_</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1382.v7d694476f340</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentTestAction/summary.jelly
@@ -1,13 +1,14 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core">
 
 	<tr><td>
 	<h3>${%Attachments}</h3>
-	<table class="pane" id="attachments">
-		<tr>
-			<td class="pane-header">${%Files}</td>
-		</tr>
+	<table class="jenkins-table" id="attachments">
+		<thead>
+			<tr>
+				<th class="pane-header">${%Files}</th>
+			</tr>
+		</thead>
 		<j:forEach var="attachment" items="${it.attachments}">
 			<tr>
 				<td class="pane">


### PR DESCRIPTION
The change proposed utilizes the `jenkins-table` tag to align the attachments table with the layout of other modern tables of the Jenkins UI.

Current layout:
![Bildschirmfoto 2022-05-26 um 13 56 53](https://user-images.githubusercontent.com/13383509/170484039-05dde557-9335-490c-a204-316ca27b1fe1.png)

Proposed change:
![Bildschirmfoto 2022-05-26 um 13 54 54](https://user-images.githubusercontent.com/13383509/170484071-ff9df704-647b-4b31-9e03-5afdb60194b3.png)

The plugin is labeled as up for adoption, but maybe you want to take a look nevertheless @jglick.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue