### PR TITLE
Prepare for API change in JUnit.

### DIFF
--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
@@ -40,6 +40,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -78,7 +79,7 @@ public class AttachmentPublisherPipelineTest {
         TestResultAction action = getTestResultActionForPipeline("workspace2.zip", "pipelineTest.groovy", Result.UNSTABLE);
 
         ClassResult cr = getClassResult(action, TEST_PACKAGE, "SignupTest");
-        List<CaseResult> caseResults = cr.getChildren();
+        Collection<CaseResult> caseResults = cr.getChildren();
         assertEquals(3, caseResults.size());
 
         CaseResult failingCase = cr.getCaseResult("A_003_Type_the_text__jenkins__into_the_field__username_");

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherTest.java
@@ -25,6 +25,7 @@ import hudson.tasks.test.TestResult;
 import hudson.util.DescribableList;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Rule;
@@ -88,7 +89,7 @@ public class AttachmentPublisherTest {
         TestResultAction action = getTestResultActionForBuild("workspace2.zip", Result.UNSTABLE);
 
         ClassResult classResult = getClassResult(action, "SignupTest");
-        List<CaseResult> cases = classResult.getChildren();
+        List<CaseResult> cases = new ArrayList<>(classResult.getChildren());
         assertEquals(3, cases.size());
 
         // Each test case should have the respective one attachment
@@ -103,7 +104,7 @@ public class AttachmentPublisherTest {
         TestResultAction action = getTestResultActionForBuild("workspace3.zip", Result.UNSTABLE);
 
         ClassResult classResult = getClassResult(action, "SignupTest");
-        List<CaseResult> cases = classResult.getChildren();
+        List<CaseResult> cases = new ArrayList<>(classResult.getChildren());
         assertEquals(3, cases.size());
 
         // Each test case should have the respective one attachment
@@ -127,7 +128,7 @@ public class AttachmentPublisherTest {
         TestResultAction action = getTestResultActionForBuild("workspace2.zip", Result.UNSTABLE);
 
         ClassResult classResult = getClassResult(action, "LoginTest");
-        List<CaseResult> cases = classResult.getChildren();
+        List<CaseResult> cases = new ArrayList<>(classResult.getChildren());
         assertEquals(4, cases.size());
 
         // Each test case should have the respective one (or zero) attachments
@@ -154,7 +155,7 @@ public class AttachmentPublisherTest {
         TestResultAction action = getTestResultActionForBuild("workspace2.zip", Result.UNSTABLE);
 
         ClassResult classResult = getClassResult(action, "MiscTest1");
-        List<CaseResult> cases = classResult.getChildren();
+        List<CaseResult> cases = new ArrayList<>(classResult.getChildren());
         assertEquals(1, cases.size());
 
         // Attachment should not be inherited from testsuite
@@ -177,7 +178,7 @@ public class AttachmentPublisherTest {
         TestResultAction action = getTestResultActionForBuild("workspace2.zip", Result.UNSTABLE);
 
         ClassResult classResult = getClassResult(action, "MiscTest2");
-        List<CaseResult> cases = classResult.getChildren();
+        List<CaseResult> cases = new ArrayList<>(classResult.getChildren());
         assertEquals(2, cases.size());
 
         // Alphabetically first comes the "doNothing" test


### PR DESCRIPTION
Improve compatibility in advance to https://github.com/jenkinsci/junit-plugin/pull/625

Fixes
`java.lang.NoSuchMethodError: 'java.util.List hudson.tasks.junit.ClassResult.getChildren()'`

### Testing done

Unit Tests run locally

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
