### PR TITLE
bug: Correct hrefs for attachments in Standard Output (#153)

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
@@ -5,63 +5,61 @@ import hudson.Util;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.tasks.junit.TestAction;
 import hudson.tasks.test.TestObject;
-
 import java.util.List;
-
 import jenkins.model.Jenkins;
 
 public class AttachmentTestAction extends TestAction {
 
-    private final FilePath storage;
-    private final List<String> attachments;
-    private final TestObject testObject;
+	private final FilePath storage;
+	private final List<String> attachments;
+	private final TestObject testObject;
 
-    public AttachmentTestAction(TestObject testObject, FilePath storage, List<String> attachments) {
-        this.storage = storage;
-        this.testObject = testObject;
-        this.attachments = attachments;
-    }
+	public AttachmentTestAction(TestObject testObject, FilePath storage, List<String> attachments) {
+		this.storage = storage;
+		this.testObject = testObject;
+		this.attachments = attachments;
+	}
 
-    public String getDisplayName() {
-        return "Attachments";
-    }
+	public String getDisplayName() {
+		return "Attachments";
+	}
 
-    public String getIconFileName() {
-        return "package.gif";
-    }
+	public String getIconFileName() {
+		return "package.gif";
+	}
 
-    public String getUrlName() {
-        return "attachments";
-    }
+	public String getUrlName() {
+		return "attachments";
+	}
 
-    public DirectoryBrowserSupport doDynamic() {
-        return new DirectoryBrowserSupport(this, storage, "Attachments", "package.gif", true);
-    }
+	public DirectoryBrowserSupport doDynamic() {
+		return new DirectoryBrowserSupport(this, storage, "Attachments", "package.gif", true);
+	}
 
-    @Override
-    public String annotate(String text) {
+	@Override
+	public String annotate(String text) {
+		String url = Jenkins.get().getRootUrl() + testObject.getUrl() + "/attachments/";
+		for (String attachment : attachments) {
+			text = text.replace(attachment, "<a href=\"" + url + attachment
+					+ "\">" + attachment + "</a>");
+		}
+		return text;
+	}
 
-        String url = Jenkins.get().getRootUrl() + testObject.getUrl() + "/attachments/";
-        for (String attachment : attachments) {
-            text = text.replace(attachment, "<a href=\"" + url + attachment
-                    + "\">" + attachment + "</a>");
-        }
-        return text;
-    }
+	public List<String> getAttachments() {
+		return attachments;
+	}
 
-    public List<String> getAttachments() {
-        return attachments;
-    }
+	public TestObject getTestObject() {
+		return testObject;
+	}
 
-    public TestObject getTestObject() {
-        return testObject;
-    }
+	public static boolean isImageFile(String filename) {
+		return filename.matches("(?i).+\\.(gif|jpe?g|png)$");
+	}
 
-    public static boolean isImageFile(String filename) {
-        return filename.matches("(?i).+\\.(gif|jpe?g|png)$");
-    }
+	public static String getUrl(String filename) {
+		return "attachments/" + Util.rawEncode(filename);
+	}
 
-    public static String getUrl(String filename) {
-        return "attachments/" + Util.rawEncode(filename);
-    }
 }

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentTestAction.java
@@ -5,63 +5,63 @@ import hudson.Util;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.tasks.junit.TestAction;
 import hudson.tasks.test.TestObject;
+
 import java.util.List;
+
 import jenkins.model.Jenkins;
 
 public class AttachmentTestAction extends TestAction {
 
-	private final FilePath storage;
-	private final List<String> attachments;
-	private final TestObject testObject;
+    private final FilePath storage;
+    private final List<String> attachments;
+    private final TestObject testObject;
 
-	public AttachmentTestAction(TestObject testObject, FilePath storage, List<String> attachments) {
-		this.storage = storage;
-		this.testObject = testObject;
-		this.attachments = attachments;
-	}
+    public AttachmentTestAction(TestObject testObject, FilePath storage, List<String> attachments) {
+        this.storage = storage;
+        this.testObject = testObject;
+        this.attachments = attachments;
+    }
 
-	public String getDisplayName() {
-		return "Attachments";
-	}
+    public String getDisplayName() {
+        return "Attachments";
+    }
 
-	public String getIconFileName() {
-		return "package.gif";
-	}
+    public String getIconFileName() {
+        return "package.gif";
+    }
 
-	public String getUrlName() {
-		return "attachments";
-	}
+    public String getUrlName() {
+        return "attachments";
+    }
 
-	public DirectoryBrowserSupport doDynamic() {
-		return new DirectoryBrowserSupport(this, storage, "Attachments", "package.gif", true);
-	}
+    public DirectoryBrowserSupport doDynamic() {
+        return new DirectoryBrowserSupport(this, storage, "Attachments", "package.gif", true);
+    }
 
-	@Override
-	public String annotate(String text) {
-		String url = Jenkins.getActiveInstance().getRootUrl()
-				+ testObject.getRun().getUrl() + "testReport"
-				+ testObject.getUrl() + "/attachments/";
-		for (String attachment : attachments) {
-			text = text.replace(attachment, "<a href=\"" + url + attachment
-					+ "\">" + attachment + "</a>");
-		}
-		return text;
-	}
+    @Override
+    public String annotate(String text) {
 
-	public List<String> getAttachments() {
-		return attachments;
-	}
+        String url = Jenkins.get().getRootUrl() + testObject.getUrl() + "/attachments/";
+        for (String attachment : attachments) {
+            text = text.replace(attachment, "<a href=\"" + url + attachment
+                    + "\">" + attachment + "</a>");
+        }
+        return text;
+    }
 
-	public TestObject getTestObject() {
-		return testObject;
-	}
+    public List<String> getAttachments() {
+        return attachments;
+    }
 
-	public static boolean isImageFile(String filename) {
-		return filename.matches("(?i).+\\.(gif|jpe?g|png)$");
-	}
+    public TestObject getTestObject() {
+        return testObject;
+    }
 
-	public static String getUrl(String filename) {
-		return "attachments/" + Util.rawEncode(filename);
-	}
+    public static boolean isImageFile(String filename) {
+        return filename.matches("(?i).+\\.(gif|jpe?g|png)$");
+    }
 
+    public static String getUrl(String filename) {
+        return "attachments/" + Util.rawEncode(filename);
+    }
 }


### PR DESCRIPTION
Please see (#153) this is a fix for that issue

### Testing done

Ran the plugin locally and processed some test results, verified that the URLS in the hrefs are now correct and work as intended.

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
