### PR TITLE
Add option to show/not show attachments at test class level (#156)

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -81,6 +81,7 @@ public class AttachmentPublisher extends TestDataPublisher {
 
         /**
          * @param attachmentsMap { fully-qualified test class name → { test method name → [ attachment file name ] } }
+         * @param showAttachmentsAtClassLevel Whether to display test case attachments at the test class level
          */
         public Data(
                 Map<String, Map<String, List<String>>> attachmentsMap,

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -38,13 +38,6 @@ public class AttachmentPublisher extends TestDataPublisher {
         this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
     }
 
-    protected Object readResolve() {
-        if (this.showAttachmentsAtClassLevel == null) {
-            this.showAttachmentsAtClassLevel = true;
-        }
-        return this;
-    }
-
     public static FilePath getAttachmentPath(Run<?, ?> build) {
         return new FilePath(new File(build.getRootDir().getAbsolutePath()))
                 .child("junit-attachments");
@@ -69,7 +62,7 @@ public class AttachmentPublisher extends TestDataPublisher {
             return null;
         }
 
-        return new Data(attachments, this.showAttachmentsAtClassLevel);
+        return new Data(attachments, isShowAttachmentsAtClassLevel());
     }
 
     public static class Data extends TestResultAction.Data {
@@ -77,7 +70,7 @@ public class AttachmentPublisher extends TestDataPublisher {
         @Deprecated
         private transient Map<String, List<String>> attachments;
         private Map<String, Map<String, List<String>>> attachmentsMap;
-        private final boolean showAttachmentsAtClassLevel;
+        private Boolean showAttachmentsAtClassLevel;
 
         /**
          * @param attachmentsMap { fully-qualified test class name → { test method name → [ attachment file name ] } }
@@ -85,7 +78,7 @@ public class AttachmentPublisher extends TestDataPublisher {
          */
         public Data(
                 Map<String, Map<String, List<String>>> attachmentsMap,
-                boolean showAttachmentsAtClassLevel) {
+                Boolean showAttachmentsAtClassLevel) {
             this.attachmentsMap = attachmentsMap;
             this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
         }
@@ -162,6 +155,10 @@ public class AttachmentPublisher extends TestDataPublisher {
 
         /** Handles migration from the old serialisation format. */
         private Object readResolve() {
+            if (this.showAttachmentsAtClassLevel == null) {
+                this.showAttachmentsAtClassLevel = true;
+            }
+
             if (attachments != null && attachmentsMap == null) {
                 // Migrate from the flat list per test class to a map of <test method, attachments>
                 attachmentsMap = new HashMap<String, Map<String, List<String>>>();

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -1,8 +1,6 @@
 package hudson.plugins.junitattachments;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.*;
-import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -1,6 +1,7 @@
 package hudson.plugins.junitattachments;
 
-import hudson.model.*;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -8,6 +9,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.model.Descriptor;
 import hudson.tasks.junit.TestAction;
 import hudson.tasks.junit.TestDataPublisher;
 import hudson.tasks.junit.TestResult;
@@ -19,7 +21,13 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class AttachmentPublisher extends TestDataPublisher {
 

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="Show attachments at test class level" field="showAttachmentsAtClassLevel">
+        <f:checkbox checked="${it.showAttachmentsAtClassLevel}"/>
+    </f:entry>
+</j:jelly>


### PR DESCRIPTION
Added a new option for the attachments published that allows the user to decide whether or not to display attachments at a test class level. This option defaults to true for existing and future configurations so as to maintain the current behaviour.

### Testing done

I have tested this by running the plugin myself manually. I have tested it for pre-existing configurations and for new configurations and the new option is all working as intended.

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
