### PR TITLE
feat: Add option to hide list of attachments in standard output (#163)

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -30,6 +30,7 @@ import java.util.TreeMap;
 public class AttachmentPublisher extends TestDataPublisher {
 
     private Boolean showAttachmentsAtClassLevel = true;
+    private Boolean showAttachmentsInStdOut = true;
 
     @DataBoundConstructor
     public AttachmentPublisher() {
@@ -39,9 +40,18 @@ public class AttachmentPublisher extends TestDataPublisher {
         return showAttachmentsAtClassLevel != null ? showAttachmentsAtClassLevel : true;
     }
 
+    public boolean isShowAttachmentsInStdOut() {
+        return showAttachmentsInStdOut != null ? showAttachmentsInStdOut : true;
+    }
+
     @DataBoundSetter
     public void setShowAttachmentsAtClassLevel(Boolean showAttachmentsAtClassLevel) {
         this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
+    }
+
+    @DataBoundSetter
+    public void setShowAttachmentsInStdOut(Boolean showAttachmentsInStdOut) {
+        this.showAttachmentsInStdOut = showAttachmentsInStdOut;
     }
 
     public static FilePath getAttachmentPath(Run<?, ?> build) {
@@ -72,7 +82,7 @@ public class AttachmentPublisher extends TestDataPublisher {
             return null;
         }
 
-        return new Data(attachments, isShowAttachmentsAtClassLevel());
+        return new Data(attachments, isShowAttachmentsAtClassLevel(), isShowAttachmentsInStdOut());
     }
 
     public static class Data extends TestResultAction.Data {
@@ -81,6 +91,7 @@ public class AttachmentPublisher extends TestDataPublisher {
         private transient Map<String, List<String>> attachments;
         private Map<String, Map<String, List<String>>> attachmentsMap;
         private Boolean showAttachmentsAtClassLevel;
+        private Boolean showAttachmentsInStdOut;
 
         /**
          * @param attachmentsMap { fully-qualified test class name → { test method name → [ attachment file name ] } }
@@ -88,9 +99,11 @@ public class AttachmentPublisher extends TestDataPublisher {
          */
         public Data(
                 Map<String, Map<String, List<String>>> attachmentsMap,
-                Boolean showAttachmentsAtClassLevel) {
+                Boolean showAttachmentsAtClassLevel,
+                Boolean showAttachmentsInStdOut) {
             this.attachmentsMap = attachmentsMap;
             this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
+            this.showAttachmentsInStdOut = showAttachmentsInStdOut;
         }
 
         @Override
@@ -157,7 +170,7 @@ public class AttachmentPublisher extends TestDataPublisher {
                         getAttachmentPath(root, fullName, testName);
 
                 action = new TestCaseAttachmentTestAction(
-                        (CaseResult) testObject, attachmentsDirectory, attachmentPaths);
+                        (CaseResult) testObject, attachmentsDirectory, attachmentPaths, showAttachmentsInStdOut);
             }
 
             return Collections.<TestAction> singletonList(action);
@@ -167,6 +180,10 @@ public class AttachmentPublisher extends TestDataPublisher {
         private Object readResolve() {
             if (this.showAttachmentsAtClassLevel == null) {
                 this.showAttachmentsAtClassLevel = true;
+            }
+
+            if (this.showAttachmentsInStdOut == null) {
+                this.showAttachmentsInStdOut = true;
             }
 
             if (attachments != null && attachmentsMap == null) {

--- a/src/main/java/hudson/plugins/junitattachments/TestCaseAttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/TestCaseAttachmentTestAction.java
@@ -6,15 +6,21 @@ import hudson.tasks.junit.CaseResult;
 import jenkins.model.Jenkins;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class TestCaseAttachmentTestAction extends AttachmentTestAction {
 
-    private final List<String> attachments;
+    private static final Pattern ATTACHMENT_PATTERN = Pattern.compile("\\[\\[ATTACHMENT\\|.+]]");
 
-    public TestCaseAttachmentTestAction(CaseResult caseResult, FilePath storage, List<String> attachments) {
+    private final List<String> attachments;
+    private final boolean showAttachmentsInStdOut;
+
+    public TestCaseAttachmentTestAction(
+            CaseResult caseResult, FilePath storage, List<String> attachments, boolean showAttachmentsInStdOut) {
         super(caseResult, storage);
 
         this.attachments = attachments;
+        this.showAttachmentsInStdOut = showAttachmentsInStdOut;
     }
 
     public List<String> getAttachments() {
@@ -23,11 +29,17 @@ public class TestCaseAttachmentTestAction extends AttachmentTestAction {
 
     @Override
     public String annotate(String text) {
+
+        if (!showAttachmentsInStdOut) {
+            text = ATTACHMENT_PATTERN.matcher(text).replaceAll("").stripTrailing();
+        }
+
         String url = Jenkins.get().getRootUrl() + testObject.getUrl() + "/attachments/";
         for (String attachment : attachments) {
             text = text.replace(attachment, "<a href=\"" + url + attachment
                     + "\">" + attachment + "</a>");
         }
+
         return text;
     }
 

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
@@ -3,4 +3,7 @@
     <f:entry title="Show attachments at test class level" field="showAttachmentsAtClassLevel">
         <f:checkbox checked="${it.showAttachmentsAtClassLevel}"/>
     </f:entry>
+    <f:entry title="Keep list of attachments in standard output" field="showAttachmentsInStdOut">
+        <f:checkbox checked="${it.showAttachmentsInStdOut}"/>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
This adds a new option to allow the [[ATTACHMENT|...]] bits in Standard Output to be removed from the report shown in Jenkins to the user. These statements can be a lot of ugly noise especially if there are a lot and they don't really provide any benefit, The most common way a user will view an attachment is using the summary table above Standard Output

### Testing done

Tested for old builds created before change. Tested for new builds with and without option set.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
