### PR TITLE
feat: Add option to preserve directory structure for attachments (#165)

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -31,7 +31,7 @@ public class AttachmentPublisher extends TestDataPublisher {
 
     private Boolean showAttachmentsAtClassLevel = true;
     private Boolean showAttachmentsInStdOut = true;
-    private Boolean maintainAttachmentsDirectoryStructure = false;
+    private Boolean keepAttachmentsDirectories = false;
 
     @DataBoundConstructor
     public AttachmentPublisher() {
@@ -45,8 +45,8 @@ public class AttachmentPublisher extends TestDataPublisher {
         return showAttachmentsInStdOut != null ? showAttachmentsInStdOut : true;
     }
 
-    public boolean isMaintainAttachmentsDirectoryStructure() {
-        return maintainAttachmentsDirectoryStructure != null ? maintainAttachmentsDirectoryStructure : false;
+    public boolean isKeepAttachmentsDirectories() {
+        return keepAttachmentsDirectories != null ? keepAttachmentsDirectories : false;
     }
 
     @DataBoundSetter
@@ -60,8 +60,8 @@ public class AttachmentPublisher extends TestDataPublisher {
     }
 
     @DataBoundSetter
-    public void setMaintainAttachmentsDirectoryStructure(Boolean maintainAttachmentsDirectoryStructure) {
-        this.maintainAttachmentsDirectoryStructure = maintainAttachmentsDirectoryStructure;
+    public void setKeepAttachmentsDirectories(Boolean keepAttachmentsDirectories) {
+        this.keepAttachmentsDirectories = keepAttachmentsDirectories;
     }
 
     public static FilePath getAttachmentPath(Run<?, ?> build) {
@@ -86,7 +86,7 @@ public class AttachmentPublisher extends TestDataPublisher {
                                    TaskListener listener, TestResult testResult) throws IOException,
             InterruptedException {
         final GetTestDataMethodObject methodObject = new GetTestDataMethodObject(build, workspace, launcher, listener, testResult);
-        Map<String, Map<String, List<String>>> attachments = methodObject.getAttachments(isMaintainAttachmentsDirectoryStructure());
+        Map<String, Map<String, List<String>>> attachments = methodObject.getAttachments(isKeepAttachmentsDirectories());
 
         if (attachments.isEmpty()) {
             return null;
@@ -96,7 +96,7 @@ public class AttachmentPublisher extends TestDataPublisher {
             attachments,
             isShowAttachmentsAtClassLevel(),
             isShowAttachmentsInStdOut(),
-            isMaintainAttachmentsDirectoryStructure());
+            isKeepAttachmentsDirectories());
     }
 
     public static class Data extends TestResultAction.Data {
@@ -106,7 +106,7 @@ public class AttachmentPublisher extends TestDataPublisher {
         private Map<String, Map<String, List<String>>> attachmentsMap;
         private Boolean showAttachmentsAtClassLevel;
         private Boolean showAttachmentsInStdOut;
-        private Boolean maintainAttachmentsDirectoryStructure;
+        private Boolean keepAttachmentsDirectories;
 
         /**
          * @param attachmentsMap { fully-qualified test class name → { test method name → [ attachment file name ] } }
@@ -116,11 +116,11 @@ public class AttachmentPublisher extends TestDataPublisher {
                 Map<String, Map<String, List<String>>> attachmentsMap,
                 Boolean showAttachmentsAtClassLevel,
                 Boolean showAttachmentsInStdOut,
-                Boolean maintainAttachmentsDirectoryStructure) {
+                Boolean keepAttachmentsDirectories) {
             this.attachmentsMap = attachmentsMap;
             this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
             this.showAttachmentsInStdOut = showAttachmentsInStdOut;
-            this.maintainAttachmentsDirectoryStructure = maintainAttachmentsDirectoryStructure;
+            this.keepAttachmentsDirectories = keepAttachmentsDirectories;
         }
 
         @Override
@@ -203,8 +203,8 @@ public class AttachmentPublisher extends TestDataPublisher {
                 this.showAttachmentsInStdOut = true;
             }
 
-            if (this.maintainAttachmentsDirectoryStructure == null) {
-                this.maintainAttachmentsDirectoryStructure = false;
+            if (this.keepAttachmentsDirectories == null) {
+                this.keepAttachmentsDirectories = false;
             }
 
             if (attachments != null && attachmentsMap == null) {

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -31,6 +31,7 @@ public class AttachmentPublisher extends TestDataPublisher {
 
     private Boolean showAttachmentsAtClassLevel = true;
     private Boolean showAttachmentsInStdOut = true;
+    private Boolean maintainAttachmentsDirectoryStructure = false;
 
     @DataBoundConstructor
     public AttachmentPublisher() {
@@ -44,6 +45,10 @@ public class AttachmentPublisher extends TestDataPublisher {
         return showAttachmentsInStdOut != null ? showAttachmentsInStdOut : true;
     }
 
+    public boolean isMaintainAttachmentsDirectoryStructure() {
+        return maintainAttachmentsDirectoryStructure != null ? maintainAttachmentsDirectoryStructure : false;
+    }
+
     @DataBoundSetter
     public void setShowAttachmentsAtClassLevel(Boolean showAttachmentsAtClassLevel) {
         this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
@@ -52,6 +57,11 @@ public class AttachmentPublisher extends TestDataPublisher {
     @DataBoundSetter
     public void setShowAttachmentsInStdOut(Boolean showAttachmentsInStdOut) {
         this.showAttachmentsInStdOut = showAttachmentsInStdOut;
+    }
+
+    @DataBoundSetter
+    public void setMaintainAttachmentsDirectoryStructure(Boolean maintainAttachmentsDirectoryStructure) {
+        this.maintainAttachmentsDirectoryStructure = maintainAttachmentsDirectoryStructure;
     }
 
     public static FilePath getAttachmentPath(Run<?, ?> build) {
@@ -76,13 +86,17 @@ public class AttachmentPublisher extends TestDataPublisher {
                                    TaskListener listener, TestResult testResult) throws IOException,
             InterruptedException {
         final GetTestDataMethodObject methodObject = new GetTestDataMethodObject(build, workspace, launcher, listener, testResult);
-        Map<String, Map<String, List<String>>> attachments = methodObject.getAttachments();
+        Map<String, Map<String, List<String>>> attachments = methodObject.getAttachments(isMaintainAttachmentsDirectoryStructure());
 
         if (attachments.isEmpty()) {
             return null;
         }
 
-        return new Data(attachments, isShowAttachmentsAtClassLevel(), isShowAttachmentsInStdOut());
+        return new Data(
+            attachments,
+            isShowAttachmentsAtClassLevel(),
+            isShowAttachmentsInStdOut(),
+            isMaintainAttachmentsDirectoryStructure());
     }
 
     public static class Data extends TestResultAction.Data {
@@ -92,6 +106,7 @@ public class AttachmentPublisher extends TestDataPublisher {
         private Map<String, Map<String, List<String>>> attachmentsMap;
         private Boolean showAttachmentsAtClassLevel;
         private Boolean showAttachmentsInStdOut;
+        private Boolean maintainAttachmentsDirectoryStructure;
 
         /**
          * @param attachmentsMap { fully-qualified test class name → { test method name → [ attachment file name ] } }
@@ -100,10 +115,12 @@ public class AttachmentPublisher extends TestDataPublisher {
         public Data(
                 Map<String, Map<String, List<String>>> attachmentsMap,
                 Boolean showAttachmentsAtClassLevel,
-                Boolean showAttachmentsInStdOut) {
+                Boolean showAttachmentsInStdOut,
+                Boolean maintainAttachmentsDirectoryStructure) {
             this.attachmentsMap = attachmentsMap;
             this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
             this.showAttachmentsInStdOut = showAttachmentsInStdOut;
+            this.maintainAttachmentsDirectoryStructure = maintainAttachmentsDirectoryStructure;
         }
 
         @Override
@@ -184,6 +201,10 @@ public class AttachmentPublisher extends TestDataPublisher {
 
             if (this.showAttachmentsInStdOut == null) {
                 this.showAttachmentsInStdOut = true;
+            }
+
+            if (this.maintainAttachmentsDirectoryStructure == null) {
+                this.maintainAttachmentsDirectoryStructure = false;
             }
 
             if (attachments != null && attachmentsMap == null) {

--- a/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
+++ b/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
@@ -319,7 +319,11 @@ public class GetTestDataMethodObject {
 
         Path commonBase = Paths.get(iterator.next().getRemote()).toAbsolutePath().normalize();
         if (filePaths.size() == 1) {
-            return new FilePath(commonBase.getParent().toFile());
+            Path parent = commonBase.getParent();
+            if (parent == null) {
+                throw new IllegalStateException("Cannot determine base directory because the file path is a root path: " + commonBase);
+            }
+            return new FilePath(parent.toFile());
         }
 
         while (iterator.hasNext()) {
@@ -340,7 +344,17 @@ public class GetTestDataMethodObject {
         while (i < minCount && p1.getName(i).equals(p2.getName(i))) {
             i++;
         }
-        return i == 0 ? null : p1.getRoot().resolve(p1.subpath(0, i));
+
+        if (i == 0) {
+            return null;
+        }
+
+        Path root = p1.getRoot();
+        if (root == null) {
+            throw new IllegalArgumentException("Expected absolute paths but got a relative path: " + p1);
+        }
+
+        return root.resolve(p1.subpath(0, i));
     }
 
 }

--- a/src/main/java/hudson/plugins/junitattachments/TestCaseAttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/TestCaseAttachmentTestAction.java
@@ -5,12 +5,15 @@ import hudson.Util;
 import hudson.tasks.junit.CaseResult;
 import jenkins.model.Jenkins;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class TestCaseAttachmentTestAction extends AttachmentTestAction {
 
     private static final Pattern ATTACHMENT_PATTERN = Pattern.compile("\\[\\[ATTACHMENT\\|.+]]");
+    private static final Pattern OUTSIDE_ANCHOR_PATTERN = Pattern.compile("(?s)(?:^|</a>)(.*?)(?=<a\\b|$)", Pattern.CASE_INSENSITIVE);
 
     private final List<String> attachments;
     private final boolean showAttachmentsInStdOut;
@@ -35,15 +38,33 @@ public class TestCaseAttachmentTestAction extends AttachmentTestAction {
         }
 
         String url = Jenkins.get().getRootUrl() + testObject.getUrl() + "/attachments/";
-        for (String attachment : attachments) {
-            text = text.replace(attachment, "<a href=\"" + url + attachment
-                    + "\">" + attachment + "</a>");
+
+        var attachmentsDescendingOrderByFilePathLength = attachments.stream()
+                .sorted(Comparator.comparingInt(String::length).reversed())
+                .toList();
+
+        for (String attachment : attachmentsDescendingOrderByFilePathLength) {
+            var attachmentPattern = Pattern.compile("\\b" + Pattern.quote(attachment) + "\\b");
+            var attachmentLink = "<a href=\"" + url + attachment.replace('\\', '/') + "\">" + attachment + "</a>";
+
+            var result = new StringBuilder();
+            Matcher outsideMatcher = OUTSIDE_ANCHOR_PATTERN.matcher(text);
+            while (outsideMatcher.find()) {
+                var fullMatch = outsideMatcher.group(0);
+                var chunk = outsideMatcher.group(1);
+                Matcher filenameMatcher = attachmentPattern.matcher(chunk);
+                String replacedChunk = filenameMatcher.replaceAll(Matcher.quoteReplacement(attachmentLink));
+                outsideMatcher.appendReplacement(result, Matcher.quoteReplacement(fullMatch.replace(chunk, replacedChunk)));
+            }
+
+            outsideMatcher.appendTail(result);
+            text = result.toString();
         }
 
         return text;
     }
 
     public static String getUrl(String filename) {
-        return "attachments/" + Util.rawEncode(filename);
+        return "attachments/" + Util.rawEncode(filename.replace('\\', '/'));
     }
 }

--- a/src/main/java/hudson/plugins/junitattachments/TestClassAttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/TestClassAttachmentTestAction.java
@@ -29,9 +29,9 @@ public class TestClassAttachmentTestAction extends AttachmentTestAction {
 
     public String getUrl(String testCase, String filename) {
         if (this.attachmentsStoredAtClassLevel) {
-            return "attachments/" + Util.rawEncode(filename);
+            return "attachments/" + Util.rawEncode(filename.replace('\\', '/'));
         }
 
-        return "attachments/" + Util.rawEncode(testCase) + "/" + Util.rawEncode(filename);
+        return "attachments/" + Util.rawEncode(testCase) + "/" + Util.rawEncode(filename.replace('\\', '/'));
     }
 }

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
@@ -7,7 +7,7 @@
         <f:checkbox checked="${it.showAttachmentsInStdOut}"/>
     </f:entry>
     <f:entry title="Maintain the original directory structure of the attachments for each test case"
-             field="maintainAttachmentsDirectoryStructure">
-        <f:checkbox checked="${it.maintainAttachmentsDirectoryStructure}"/>
+             field="keepAttachmentsDirectories">
+        <f:checkbox checked="${it.keepAttachmentsDirectories}"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
@@ -6,4 +6,8 @@
     <f:entry title="Keep list of attachments in standard output" field="showAttachmentsInStdOut">
         <f:checkbox checked="${it.showAttachmentsInStdOut}"/>
     </f:entry>
+    <f:entry title="Whether to maintain the original directory structure of the attachments for each test case"
+             field="maintainAttachmentsDirectoryStructure">
+        <f:checkbox checked="${it.maintainAttachmentsDirectoryStructure}"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/AttachmentPublisher/config.jelly
@@ -6,7 +6,7 @@
     <f:entry title="Keep list of attachments in standard output" field="showAttachmentsInStdOut">
         <f:checkbox checked="${it.showAttachmentsInStdOut}"/>
     </f:entry>
-    <f:entry title="Whether to maintain the original directory structure of the attachments for each test case"
+    <f:entry title="Maintain the original directory structure of the attachments for each test case"
              field="maintainAttachmentsDirectoryStructure">
         <f:checkbox checked="${it.maintainAttachmentsDirectoryStructure}"/>
     </f:entry>


### PR DESCRIPTION
This adds the option to be able to preserve the original directory structure of any attachments. With the option enabled it will determine the common base path for all the attachments for each test case. It will then maintain that relative directory structure when archiving the attachments for the build. 

![image](https://github.com/user-attachments/assets/6e7fc4a6-1040-4116-8e36-56c5475c8064)


### Testing done

Tested for old builds created before change. Tested for new builds with and without option set.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
