### PR TITLE
Fix table in dark mode

### DIFF
--- a/src/main/resources/hudson/plugins/junitattachments/TestCaseAttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/TestCaseAttachmentTestAction/summary.jelly
@@ -1,17 +1,14 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
-	<tr><td>
-	<h3>${%Attachments}</h3>
-	<table class="jenkins-table" id="attachments">
+	<h1>${%Attachments}</h1>
+	<table class="jenkins-table sortable" id="attachments">
 		<thead>
-			<tr>
-				<th class="pane-header">${%Files}</th>
-			</tr>
+			<th>${%Files}</th>
 		</thead>
 		<j:forEach var="attachment" items="${it.attachments}">
 			<tr>
-				<td class="pane">
+				<td>
 					<a class="${it.isImageFile(attachment) ? 'gallery' : ''}"
 						 title="${attachment}"
 						 href="${it.getUrl(attachment)}">${attachment}</a>
@@ -19,5 +16,5 @@
 			</tr>
 		</j:forEach>
 	</table>
-	</td></tr>
+
 </j:jelly>

--- a/src/main/resources/hudson/plugins/junitattachments/TestCaseAttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/TestCaseAttachmentTestAction/summary.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
-	<h1>${%Attachments}</h1>
+	<h2>${%Attachments}</h2>
 	<table class="jenkins-table sortable" id="attachments">
 		<thead>
 			<th>${%Files}</th>

--- a/src/main/resources/hudson/plugins/junitattachments/TestClassAttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/TestClassAttachmentTestAction/summary.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
-	<h1>${%Attachments}</h1>
+	<h2>${%Attachments}</h2>
 	<table class="jenkins-table sortable" id="attachments">
 		<thead>
 			<th>${%Test Case}</th>

--- a/src/main/resources/hudson/plugins/junitattachments/TestClassAttachmentTestAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/junitattachments/TestClassAttachmentTestAction/summary.jelly
@@ -1,20 +1,17 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
-	<tr><td>
-	<h3>${%Attachments}</h3>
-	<table class="jenkins-table" id="attachments">
+	<h1>${%Attachments}</h1>
+	<table class="jenkins-table sortable" id="attachments">
 		<thead>
-			<tr>
-				<th class="pane-header">${%Test Case}</th>
-				<th class="pane-header">${%Files}</th>
-			</tr>
+			<th>${%Test Case}</th>
+			<th>${%Files}</th>
 		</thead>
 		<j:forEach var="entry" items="${it.attachments.entrySet()}">
 			<j:forEach var="file" items="${entry.value}">
 				<tr>
-					<td class="pane">${entry.key}</td>
-					<td class="pane">
+					<td>${entry.key}</td>
+					<td>
 						<j:set var="fileUrl" value="${it.getUrl(entry.key, file)}" />
 						<a class="${it.isImageFile(file) ? 'gallery' : ''}"
 							 title="${fileUrl}"
@@ -24,5 +21,4 @@
 			</j:forEach>
 		</j:forEach>
 	</table>
-	</td></tr>
 </j:jelly>


### PR DESCRIPTION
Fix https://github.com/jenkinsci/junit-attachments-plugin/issues/183

### Testing done

**With 2.516**

<img width="1587" height="563" alt="attachment1" src="https://github.com/user-attachments/assets/0db8e729-ec8e-4991-85ac-ed627b7d78a8" />

<img width="1670" height="512" alt="attachment2" src="https://github.com/user-attachments/assets/4fd6409e-540c-4d6d-9f81-2787d895464e" />

**With 2.492**

<img width="1605" height="573" alt="attachment3" src="https://github.com/user-attachments/assets/fe366f3c-48da-460f-9043-1789d111ffb5" />

<img width="1582" height="450" alt="attachment4" src="https://github.com/user-attachments/assets/d3d56048-f6d3-4f54-b399-2156d3c3109f" />





### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
