### PR TITLE
Handle attachments from the "same" test from different branches/nodes

### DIFF
--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -20,6 +20,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -106,7 +107,7 @@ public class AttachmentPublisher extends TestDataPublisher {
             this.attachmentsMap = attachmentsMap;
             this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
             this.showAttachmentsInStdOut = showAttachmentsInStdOut;
-            this.enclosingBlocks = enclosingBlocks;
+            this.enclosingBlocks = enclosingBlocks == null ? null : new ArrayList<>(enclosingBlocks);
         }
 
         @Override

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -142,12 +142,11 @@ public class AttachmentPublisher extends TestDataPublisher {
                 packageName = testObject.getParent().getName();
                 className = testObject.getName();
                 testName = null;
-            } else if (testObject instanceof CaseResult) {
+            } else if (testObject instanceof CaseResult caseResult) {
                 // We're looking at the page for an individual test (i.e. a single @Test method)
 
                 // If enclosingBlocks is non-empty, filter by matching enclosing flow node IDs
                 if (enclosingBlocks != null && !enclosingBlocks.isEmpty()) {
-                    CaseResult caseResult = (CaseResult) testObject;
                     if (!enclosingBlocks.equals(caseResult.getSuiteResult().getEnclosingBlocks())) {
                         return Collections.emptyList();
                     }
@@ -172,7 +171,6 @@ public class AttachmentPublisher extends TestDataPublisher {
 
             FilePath root = getAttachmentPath(testObject.getRun());
             if (enclosingBlocks != null && !enclosingBlocks.isEmpty()) {
-                // TODO sanitize
                 root = root.child(String.join("-", enclosingBlocks));
             }
             // Historical builds might have attachments stored in class level directories
@@ -180,15 +178,16 @@ public class AttachmentPublisher extends TestDataPublisher {
 
             // Return a single TestAction which will display the attached files
             AttachmentTestAction action;
-            if (testObject instanceof ClassResult) {
+            if (testObject instanceof ClassResult cr) {
                 // Ensure attachments are shown in the same order as the tests
                 TreeMap<String, List<String>> sortedTests = new TreeMap<String, List<String>>(tests);
 
                 action = new TestClassAttachmentTestAction(
-                        (ClassResult) testObject,
+                        cr,
                         getAttachmentPath(root, fullName, null),
                         sortedTests,
-                        attachmentsStoredAtClassLevel);
+                        attachmentsStoredAtClassLevel,
+                        enclosingBlocks);
             }
             else {
                 List<String> attachmentPaths = tests.get(testName);

--- a/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
+++ b/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java
@@ -81,7 +81,7 @@ public class AttachmentPublisher extends TestDataPublisher {
             return null;
         }
 
-        return new Data(attachments, isShowAttachmentsAtClassLevel(), isShowAttachmentsInStdOut());
+        return new Data(attachments, isShowAttachmentsAtClassLevel(), isShowAttachmentsInStdOut(), methodObject.getEnclosingBlocks());
     }
 
     public static class Data extends TestResultAction.Data {
@@ -91,18 +91,22 @@ public class AttachmentPublisher extends TestDataPublisher {
         private Map<String, Map<String, List<String>>> attachmentsMap;
         private Boolean showAttachmentsAtClassLevel;
         private Boolean showAttachmentsInStdOut;
+        private List<String> enclosingBlocks;
 
         /**
          * @param attachmentsMap { fully-qualified test class name → { test method name → [ attachment file name ] } }
          * @param showAttachmentsAtClassLevel Whether to display test case attachments at the test class level
+         * @param enclosingBlocks Pipeline enclosing stages/blocks used to namespace storage and filter actions
          */
         public Data(
                 Map<String, Map<String, List<String>>> attachmentsMap,
                 Boolean showAttachmentsAtClassLevel,
-                Boolean showAttachmentsInStdOut) {
+                Boolean showAttachmentsInStdOut,
+                List<String> enclosingBlocks) {
             this.attachmentsMap = attachmentsMap;
             this.showAttachmentsAtClassLevel = showAttachmentsAtClassLevel;
             this.showAttachmentsInStdOut = showAttachmentsInStdOut;
+            this.enclosingBlocks = enclosingBlocks;
         }
 
         @Override
@@ -120,11 +124,35 @@ public class AttachmentPublisher extends TestDataPublisher {
                     return Collections.emptyList();
                 }
 
+                // If enclosingBlocks is non-empty, check that at least one child CaseResult matches
+                if (enclosingBlocks != null && !enclosingBlocks.isEmpty()) {
+                    ClassResult classResult = (ClassResult) testObject;
+                    boolean found = false;
+                    for (CaseResult child : classResult.getChildren()) {
+                        if (enclosingBlocks.equals(child.getSuiteResult().getEnclosingBlocks())) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        return Collections.emptyList();
+                    }
+                }
+
                 packageName = testObject.getParent().getName();
                 className = testObject.getName();
                 testName = null;
             } else if (testObject instanceof CaseResult) {
                 // We're looking at the page for an individual test (i.e. a single @Test method)
+
+                // If enclosingBlocks is non-empty, filter by matching enclosing flow node IDs
+                if (enclosingBlocks != null && !enclosingBlocks.isEmpty()) {
+                    CaseResult caseResult = (CaseResult) testObject;
+                    if (!enclosingBlocks.equals(caseResult.getSuiteResult().getEnclosingBlocks())) {
+                        return Collections.emptyList();
+                    }
+                }
+
                 packageName = testObject.getParent().getParent().getName();
                 className = testObject.getParent().getName();
                 testName = testObject.getName();
@@ -143,8 +171,12 @@ public class AttachmentPublisher extends TestDataPublisher {
             }
 
             FilePath root = getAttachmentPath(testObject.getRun());
+            if (enclosingBlocks != null && !enclosingBlocks.isEmpty()) {
+                // TODO sanitize
+                root = root.child(String.join("-", enclosingBlocks));
+            }
             // Historical builds might have attachments stored in class level directories
-            boolean attachmentsStoredAtClassLevel = areAttachmentsStoredAtClassLevel(root, fullName, tests);
+            boolean attachmentsStoredAtClassLevel = enclosingBlocks == null && areAttachmentsStoredAtClassLevel(root, fullName, tests);
 
             // Return a single TestAction which will display the attached files
             AttachmentTestAction action;

--- a/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
+++ b/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
@@ -103,7 +103,6 @@ public class GetTestDataMethodObject {
 
         FilePath baseStorage = AttachmentPublisher.getAttachmentPath(build);
         if (!blocks.isEmpty()) {
-            // TODO sanitize this as it is user supplied
             baseStorage = baseStorage.child(String.join("-", blocks));
         }
         this.attachmentsStorage = baseStorage;

--- a/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
+++ b/src/main/java/hudson/plugins/junitattachments/GetTestDataMethodObject.java
@@ -20,6 +20,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +53,7 @@ public class GetTestDataMethodObject {
     private final Map<String, Map<String, List<String>>> attachments = new HashMap<String, Map<String, List<String>>>();
     private final FilePath attachmentsStorage;
     private final TaskListener listener;
+    private final List<String> enclosingBlocks;
 
     /**
      * The workspace to check in for attachments.
@@ -70,6 +72,7 @@ public class GetTestDataMethodObject {
         this.build = build;
         this.testResult = testResult;
         this.listener = listener;
+        this.enclosingBlocks = Collections.emptyList();
         attachmentsStorage = AttachmentPublisher.getAttachmentPath(build);
         workspace = build.getWorkspace();
     }
@@ -86,8 +89,28 @@ public class GetTestDataMethodObject {
         this.build = build;
         this.testResult = testResult;
         this.listener = listener;
-        attachmentsStorage = AttachmentPublisher.getAttachmentPath(build);
         this.workspace = workspace;
+
+        List<String> blocks = Collections.emptyList();
+        for (SuiteResult suite : testResult.getSuites()) {
+            List<String> eb = suite.getEnclosingBlocks();
+            if (eb != null && !eb.isEmpty()) {
+                blocks = eb;
+                break;
+            }
+        }
+        this.enclosingBlocks = blocks;
+
+        FilePath baseStorage = AttachmentPublisher.getAttachmentPath(build);
+        if (!blocks.isEmpty()) {
+            // TODO sanitize this as it is user supplied
+            baseStorage = baseStorage.child(String.join("-", blocks));
+        }
+        this.attachmentsStorage = baseStorage;
+    }
+
+    public List<String> getEnclosingBlocks() {
+        return enclosingBlocks;
     }
 
     /**

--- a/src/main/java/hudson/plugins/junitattachments/TestClassAttachmentTestAction.java
+++ b/src/main/java/hudson/plugins/junitattachments/TestClassAttachmentTestAction.java
@@ -11,27 +11,39 @@ public class TestClassAttachmentTestAction extends AttachmentTestAction {
 
     private final Map<String, List<String>> attachments;
     private final boolean attachmentsStoredAtClassLevel;
+    private final List<String> blocks;
 
     public TestClassAttachmentTestAction(
             ClassResult classResult,
             FilePath storage,
             Map<String, List<String>> attachments,
-            boolean attachmentsStoredAtClassLevel) {
+            boolean attachmentsStoredAtClassLevel,
+            List<String> blocks) {
         super(classResult, storage);
 
         this.attachments = attachments;
         this.attachmentsStoredAtClassLevel = attachmentsStoredAtClassLevel;
+        this.blocks = blocks;
     }
 
     public Map<String, List<String>> getAttachments() {
         return attachments;
     }
 
+    // disambiguate actions where we have blocks for classes
+    @Override
+    public String getUrlName() {
+        if (blocks == null || blocks.isEmpty()) {
+            return "attachments";
+        }
+        return "attachments-" + String.join("-", blocks);
+    }
+
     public String getUrl(String testCase, String filename) {
         if (this.attachmentsStoredAtClassLevel) {
-            return "attachments/" + Util.rawEncode(filename);
+            return getUrlName() + "/" + Util.rawEncode(filename);
         }
 
-        return "attachments/" + Util.rawEncode(testCase) + "/" + Util.rawEncode(filename);
+        return getUrlName() + "/" + Util.rawEncode(testCase) + "/" + Util.rawEncode(filename);
     }
 }

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
@@ -148,16 +148,23 @@ class AttachmentPublisherPipelineTest {
         TestResultAction tra = run.getAction(TestResultAction.class);
         List<CaseResult> passedTests = tra.getPassedTests();
         assertThat(passedTests, hasSize(2));
+        boolean foundFirstBranch = false;
+        boolean foundSecondBranch = false;
+
         for (CaseResult cr : passedTests) {
             // which branch was this in
             List<String> branchNames = cr.getEnclosingFlowNodeNames();
             if (branchNames.contains("firstBranch")) {
-                assertThat(getTestAttachementAsText(jenkinsRule, cr), is("this is branch firstBranch"));
+                foundFirstBranch = true;
+                assertThat(getTestAttachmentAsText(jenkinsRule, cr), is("this is branch firstBranch"));
             }
             if (branchNames.contains("secondBranch")) {
-                assertThat(getTestAttachementAsText(jenkinsRule, cr), is("this is branch secondBranch"));
+                foundSecondBranch = true;
+                assertThat(getTestAttachmentAsText(jenkinsRule, cr), is("this is branch secondBranch"));
             }
         }
+        assertTrue(foundFirstBranch, "Found first branch");
+        assertTrue(foundSecondBranch, "Found second branch");
     }
 
     @Test
@@ -239,7 +246,7 @@ class AttachmentPublisherPipelineTest {
      * @return String content of the attachment for the test
      * @throws IOException if we could not obtain the test data (using HTTP to download)
      */
-    private static String getTestAttachementAsText(JenkinsRule jenkinsRule, CaseResult cr) throws IOException {
+    private static String getTestAttachmentAsText(JenkinsRule jenkinsRule, CaseResult cr) throws IOException {
         List<TestCaseAttachmentTestAction> testCaseAttachmentTestActions = cr.getTestActions().stream()
                 .filter(TestCaseAttachmentTestAction.class::isInstance)
                 .map(TestCaseAttachmentTestAction.class::cast)

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
@@ -30,8 +30,6 @@ import hudson.tasks.junit.CaseResult;
 import hudson.tasks.junit.ClassResult;
 import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.test.TestResult;
-import org.apache.commons.io.IOUtils;
-import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -53,9 +51,15 @@ import java.util.stream.Collectors;
 
 import static hudson.plugins.junitattachments.AttachmentPublisherTest.getClassResult;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @WithJenkins
 class AttachmentPublisherPipelineTest {
@@ -140,6 +144,64 @@ class AttachmentPublisherPipelineTest {
     @Test
     @Issue("https://github.com/jenkinsci/junit-attachments-plugin/issues/202")
     void testMultipleTestExecutions(JenkinsRule jenkinsRule) throws Exception {
+        WorkflowRun run = buildParallelBranchesProject(jenkinsRule);
+        TestResultAction tra = run.getAction(TestResultAction.class);
+        List<CaseResult> passedTests = tra.getPassedTests();
+        assertThat(passedTests, hasSize(2));
+        for (CaseResult cr : passedTests) {
+            // which branch was this in
+            List<String> branchNames = cr.getEnclosingFlowNodeNames();
+            if (branchNames.contains("firstBranch")) {
+                assertThat(getTestAttachementAsText(jenkinsRule, cr), is("this is branch firstBranch"));
+            }
+            if (branchNames.contains("secondBranch")) {
+                assertThat(getTestAttachementAsText(jenkinsRule, cr), is("this is branch secondBranch"));
+            }
+        }
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/junit-attachments-plugin/issues/202")
+    void testMultipleTestExecutionsClassResult(JenkinsRule jenkinsRule) throws Exception {
+        WorkflowRun run = buildParallelBranchesProject(jenkinsRule);
+        TestResultAction tra = run.getAction(TestResultAction.class);
+
+        ClassResult classResult = getClassResult(tra, "com.example", "MyTest");
+        assertNotNull(classResult);
+
+        // Each branch produces one Data, and each Data should produce one TestClassAttachmentTestAction
+        // for the ClassResult (since the ClassResult has children from both branches).
+        List<TestClassAttachmentTestAction> classActions = classResult.getTestActions().stream()
+                .filter(TestClassAttachmentTestAction.class::isInstance)
+                .map(TestClassAttachmentTestAction.class::cast)
+                .collect(Collectors.toList());
+        assertThat(classActions, hasSize(2));
+
+        // Each action should have exactly one test case with one attachment
+        // and we should have one that is "this is branch firstBranch" and one that is "this is branch secondBranch"
+        boolean foundFirstBranch = false;
+        boolean foundSecondBranch = false;
+        for (TestClassAttachmentTestAction action : classActions) {
+            assertThat(action.getAttachments(),
+                    allOf(aMapWithSize(1),
+                          hasEntry(
+                                  is("someTestWithAttachments"),
+                                  contains("attachment.txt"))));
+
+            URL url = new URL(jenkinsRule.getURL(), classResult.getUrl() + "/");
+            url = new URL(url, action.getUrl("someTestWithAttachments", "attachment.txt"));
+            String s = fromURL(url);
+            if ("this is branch firstBranch".equals(s)) {
+                foundFirstBranch = true;
+            } else if("this is branch secondBranch".equals(s)) {
+                foundSecondBranch = true;
+            }
+        }
+        assertTrue(foundFirstBranch, "Found first branch");
+        assertTrue(foundSecondBranch, "Found second branch");
+    }
+
+    private static WorkflowRun buildParallelBranchesProject(JenkinsRule jenkinsRule) throws Exception {
         WorkflowJob project = jenkinsRule.jenkins.createProject(WorkflowJob.class, "tests-in-branches");
         project.setDefinition(new CpsFlowDefinition("""
             def simulateTest(String folder) {
@@ -168,21 +230,7 @@ class AttachmentPublisherPipelineTest {
                 failFast: false
             }
                 """, true));
-
-        WorkflowRun run = jenkinsRule.buildAndAssertSuccess(project);
-        TestResultAction tra = run.getAction(TestResultAction.class);
-        List<CaseResult> passedTests = tra.getPassedTests();
-        assertThat(passedTests, hasSize(2));
-        for (CaseResult cr : passedTests) {
-            // which branch was this in
-            List<String> branchNames = cr.getEnclosingFlowNodeNames();
-            if (branchNames.contains("firstBranch")) {
-                assertThat(getTestAttachementAsText(jenkinsRule, cr), Matchers.is("this is branch firstBranch"));
-            }
-            if (branchNames.contains("secondBranch")) {
-                assertThat(getTestAttachementAsText(jenkinsRule, cr), Matchers.is("this is branch secondBranch"));
-            }
-        }
+        return jenkinsRule.buildAndAssertSuccess(project);
     }
 
     /**
@@ -202,9 +250,7 @@ class AttachmentPublisherPipelineTest {
         assertThat(testAttachmentAction.getAttachments(), hasSize(1));
         URL url = new URL(jenkinsRule.getURL(), cr.getUrl() + "/");
         url = new URL(url, TestCaseAttachmentTestAction.getUrl(testAttachmentAction.getAttachments().get(0)));
-        try (InputStream is = url.openConnection().getInputStream()) {
-            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
-        }
+        return fromURL(url);
     }
 
     // Creates a job from the given workspace zip file, builds it and retrieves the TestResultAction
@@ -233,10 +279,15 @@ class AttachmentPublisherPipelineTest {
 
         URL url = AttachmentPublisherPipelineTest.class.getResource(fileName);
         if (url != null) {
-            fileContents = IOUtils.toString(url, StandardCharsets.UTF_8);
+            fileContents = fromURL(url);
         }
 
         return fileContents;
     }
 
+    private static final String fromURL(URL url) throws IOException {
+        try (InputStream is = url.openConnection().getInputStream()) {
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
 }

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
@@ -196,8 +196,7 @@ class AttachmentPublisherPipelineTest {
                 .filter(TestCaseAttachmentTestAction.class::isInstance)
                 .map(TestCaseAttachmentTestAction.class::cast)
                 .collect(Collectors.toList());
-        // TODO there should be only one TestCaseAttachmentTestAction per CaseResult but currently we for each time a test with the same classname.testname was invoked
-        // assertThat(testCaseAttachmentTestActions, hasSize(1));
+        assertThat(testCaseAttachmentTestActions, hasSize(1));
 
         TestCaseAttachmentTestAction testAttachmentAction = testCaseAttachmentTestActions.get(0);
         assertThat(testAttachmentAction.getAttachments(), hasSize(1));

--- a/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/junitattachments/AttachmentPublisherPipelineTest.java
@@ -31,6 +31,7 @@ import hudson.tasks.junit.ClassResult;
 import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.test.TestResult;
 import org.apache.commons.io.IOUtils;
+import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -40,6 +41,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.nio.charset.StandardCharsets;
@@ -47,8 +49,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static hudson.plugins.junitattachments.AttachmentPublisherTest.getClassResult;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -129,6 +134,77 @@ class AttachmentPublisherPipelineTest {
             assertNotNull(caseAttachments);
             assertEquals(1, caseAttachments.size());
             assertEquals("attachment.txt", caseAttachments.get(0));
+        }
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/junit-attachments-plugin/issues/202")
+    void testMultipleTestExecutions(JenkinsRule jenkinsRule) throws Exception {
+        WorkflowJob project = jenkinsRule.jenkins.createProject(WorkflowJob.class, "tests-in-branches");
+        project.setDefinition(new CpsFlowDefinition("""
+            def simulateTest(String folder) {
+                dir(folder) {
+                    writeFile file: 'attachment.txt', text: "this is branch $folder"
+                    writeFile file: 'test.xml', text: '''<?xml version="1.0" encoding="UTF-8"?>
+                    <testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd" version="3.0.2" name="com.example.MyTest" time="1" tests="1" errors="0" skipped="0" failures="0">
+                      <testcase name="someTestWithAttachments" classname="com.example.MyTest" time="1">
+                        <system-out><![CDATA[This is some system.out data from branch %%BRANCH%%
+                    ]]></system-out>
+                        <system-err><![CDATA[This is some system.err.data with an attachment
+                        [[ATTACHMENT|attachment.txt]]
+                    ]]></system-err>
+                      </testcase>
+                    </testsuite>
+                            '''.replace("%%BRANCH%%", folder)
+                    junit stdioRetention: 'ALL', testDataPublishers: [attachments()], testResults: 'test.xml'
+                }
+            }
+            node {
+                parallel firstBranch: {
+                    simulateTest("firstBranch")
+                }, secondBranch: {
+                    simulateTest("secondBranch")
+                },
+                failFast: false
+            }
+                """, true));
+
+        WorkflowRun run = jenkinsRule.buildAndAssertSuccess(project);
+        TestResultAction tra = run.getAction(TestResultAction.class);
+        List<CaseResult> passedTests = tra.getPassedTests();
+        assertThat(passedTests, hasSize(2));
+        for (CaseResult cr : passedTests) {
+            // which branch was this in
+            List<String> branchNames = cr.getEnclosingFlowNodeNames();
+            if (branchNames.contains("firstBranch")) {
+                assertThat(getTestAttachementAsText(jenkinsRule, cr), Matchers.is("this is branch firstBranch"));
+            }
+            if (branchNames.contains("secondBranch")) {
+                assertThat(getTestAttachementAsText(jenkinsRule, cr), Matchers.is("this is branch secondBranch"));
+            }
+        }
+    }
+
+    /**
+     * Obtain the string content of a single attachment from a single test.
+     * @param cr the Single test to obtain the attachment for.
+     * @return String content of the attachment for the test
+     * @throws IOException if we could not obtain the test data (using HTTP to download)
+     */
+    private static String getTestAttachementAsText(JenkinsRule jenkinsRule, CaseResult cr) throws IOException {
+        List<TestCaseAttachmentTestAction> testCaseAttachmentTestActions = cr.getTestActions().stream()
+                .filter(TestCaseAttachmentTestAction.class::isInstance)
+                .map(TestCaseAttachmentTestAction.class::cast)
+                .collect(Collectors.toList());
+        // TODO there should be only one TestCaseAttachmentTestAction per CaseResult but currently we for each time a test with the same classname.testname was invoked
+        // assertThat(testCaseAttachmentTestActions, hasSize(1));
+
+        TestCaseAttachmentTestAction testAttachmentAction = testCaseAttachmentTestActions.get(0);
+        assertThat(testAttachmentAction.getAttachments(), hasSize(1));
+        URL url = new URL(jenkinsRule.getURL(), cr.getUrl() + "/");
+        url = new URL(url, TestCaseAttachmentTestAction.getUrl(testAttachmentAction.getAttachments().get(0)));
+        try (InputStream is = url.openConnection().getInputStream()) {
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 


### PR DESCRIPTION
When the same test was recorded with the same attachment paths (but on different nodes) then wen viewing test results you would only be able to see one of the attachments.

The testData now records the flow ids so that attachments from different flows can be disambiguated.

Also tested interactively by:
* without the fix, create a pipeline using the pipeline from the unit tests
* ran a build and checked the test results and data (only one branch is present)
* upgraded the plugin to a locally built version with this fix
* checked the old results where still present (only one attachment was still obtainable)
* ran a build and checked the test results and data (both attachments are available)

fixes: #202

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
